### PR TITLE
Changes from background agent bc-db5a8a6a-da8f-4820-bfe6-ae4951e0d083

### DIFF
--- a/environment/environment.go
+++ b/environment/environment.go
@@ -59,7 +59,7 @@ func New(ctx context.Context, dag *dagger.Client, id, title string, config *Envi
 	slog.Info("Creating environment", "id", env.ID, "workdir", env.State.Config.Workdir)
 
 	if env.IsHost() {
-		if err := env.applyHost(ctx); err != nil {
+		if err := env.applyHost(); err != nil {
 			return nil, err
 		}
 		return env, nil
@@ -298,7 +298,7 @@ func (env *Environment) UpdateConfig(ctx context.Context, newConfig *Environment
 	}
 
 	if env.IsHost() {
-		if err := env.applyHost(ctx); err != nil {
+		if err := env.applyHost(); err != nil {
 			return err
 		}
 		return nil
@@ -562,7 +562,7 @@ func (env *Environment) IsHost() bool {
 }
 
 // applyHost updates the environment timestamps without container state
-func (env *Environment) applyHost(ctx context.Context) error {
+func (env *Environment) applyHost() error {
 	env.mu.Lock()
 	defer env.mu.Unlock()
 	env.State.UpdatedAt = time.Now()
@@ -582,10 +582,6 @@ func combineStdoutStderr(stdout, stderr string) string {
 	return "stderr: " + stderr
 }
 
-// execEnv returns the current process environment without mutation
-func execEnv() []string {
-	return os.Environ()
-}
 
 // buildHostEnv merges host environment with configured env vars and secrets
 func (env *Environment) buildHostEnv() []string {


### PR DESCRIPTION
Remove unused `execEnv` function and `ctx` parameter from `applyHost` to resolve linter errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-db5a8a6a-da8f-4820-bfe6-ae4951e0d083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db5a8a6a-da8f-4820-bfe6-ae4951e0d083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

